### PR TITLE
Fix: Allow cc-wrapped to work without stats-cache.json

### DIFF
--- a/src/collector.ts
+++ b/src/collector.ts
@@ -59,17 +59,17 @@ export interface ClaudeUsageSummary {
 }
 
 export async function checkClaudeDataExists(): Promise<boolean> {
-  try {
-    await readFile(CLAUDE_STATS_CACHE_PATH);
-    return true;
-  } catch {
-    return false;
-  }
+  const projectsPath = join(CLAUDE_DATA_PATH, CLAUDE_PROJECTS_DIR);
+  return await pathIsDirectory(projectsPath);
 }
 
 export async function loadClaudeStatsCache(): Promise<ClaudeStatsCache> {
-  const raw = await readFile(CLAUDE_STATS_CACHE_PATH, "utf8");
-  return JSON.parse(raw) as ClaudeStatsCache;
+  try {
+    const raw = await readFile(CLAUDE_STATS_CACHE_PATH, "utf8");
+    return JSON.parse(raw) as ClaudeStatsCache;
+  } catch {
+    return {};
+  }
 }
 
 export async function collectClaudeProjects(year: number): Promise<Set<string>> {


### PR DESCRIPTION
## Summary

cc-wrapped currently requires `~/.claude/stats-cache.json` to exist, but this file is only created when the `statsCache` setting is enabled in Claude Code. This makes the tool unusable for users who haven't enabled that setting.

## Changes

- Modified `checkClaudeDataExists()` to check for `~/.claude/projects/` directory instead of `stats-cache.json`
- Made `loadClaudeStatsCache()` gracefully return an empty object when the file doesn't exist

## Why

The actual data collection (`collectClaudeUsageSummary`) reads from the `projects/` directory's JSONL files, not from `stats-cache.json`.
The stats cache is only used as a fallback data source. Therefore, requiring `stats-cache.json` for the existence check was unnecessarily restrictive.

## Test plan

- [x] Tested on a system without `stats-cache.json` - now works correctly
- [x] Verified stats are collected from `projects/` directory
