### PR TITLE
Add hint to enable statsCache for detailed stats

### DIFF
--- a/src/collector.ts
+++ b/src/collector.ts
@@ -59,17 +59,17 @@ export interface ClaudeUsageSummary {
 }
 
 export async function checkClaudeDataExists(): Promise<boolean> {
-  try {
-    await readFile(CLAUDE_STATS_CACHE_PATH);
-    return true;
-  } catch {
-    return false;
-  }
+  const projectsPath = join(CLAUDE_DATA_PATH, CLAUDE_PROJECTS_DIR);
+  return await pathIsDirectory(projectsPath);
 }
 
 export async function loadClaudeStatsCache(): Promise<ClaudeStatsCache> {
-  const raw = await readFile(CLAUDE_STATS_CACHE_PATH, "utf8");
-  return JSON.parse(raw) as ClaudeStatsCache;
+  try {
+    const raw = await readFile(CLAUDE_STATS_CACHE_PATH, "utf8");
+    return JSON.parse(raw) as ClaudeStatsCache;
+  } catch {
+    return {};
+  }
 }
 
 export async function collectClaudeProjects(year: number): Promise<Set<string>> {

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -63,6 +63,15 @@ export async function checkClaudeDataExists(): Promise<boolean> {
   return await pathIsDirectory(projectsPath);
 }
 
+export async function checkStatsCacheExists(): Promise<boolean> {
+  try {
+    await stat(CLAUDE_STATS_CACHE_PATH);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function loadClaudeStatsCache(): Promise<ClaudeStatsCache> {
   try {
     const raw = await readFile(CLAUDE_STATS_CACHE_PATH, "utf8");

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as p from "@clack/prompts";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 
-import { checkClaudeDataExists } from "./collector";
+import { checkClaudeDataExists, checkStatsCacheExists } from "./collector";
 import { calculateStats } from "./stats";
 import { generateImage } from "./image/generator";
 import { displayInTerminal, getTerminalName } from "./terminal/display";
@@ -98,6 +98,13 @@ async function main() {
   }
 
   spinner.stop("Found your stats!");
+
+  const statsCacheExists = await checkStatsCacheExists();
+  if (!statsCacheExists) {
+    p.log.info(
+      "Tip: Run `claude config set statsCache true` to enable detailed stats (tool calls, etc.)"
+    );
+  }
 
   const activityDates = Array.from(stats.dailyActivity.keys())
     .map((d) => new Date(d))


### PR DESCRIPTION
## Summary

Display a helpful tip when `stats-cache.json` is not found, guiding users to enable the `statsCache` setting for more detailed statistics.

## Changes

- Added `checkStatsCacheExists()` function to detect if stats cache is available
- Display a tip when `stats-cache.json` is not found:
  ```
  Tip: Run `claude config set statsCache true` to enable detailed stats (tool calls, etc.)
  ```

## Why

`stats-cache.json` provides additional details like tool call counts that aren't available from the `projects/` directory JSONL files. This hint helps users discover the `statsCache` setting to get richer statistics.

## Test plan

- [x] Confirmed hint message is displayed when stats cache is missing
- [x] Verified no hint is shown when stats cache exists

```
❯ bun run src/index.ts
┌  claude code wrapped
│
◇  Found your stats!
│
●  Tip: Run `claude config set statsCache true` to enable detailed stats (tool calls, etc.)
│
```
