### PR TITLE
Support `~/.config/claude` and add `--config-dir` option

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,6 @@
         "@resvg/resvg-wasm": "^2.6.2",
         "react": "^19.2.3",
         "satori": "^0.18.3",
-        "xdg-basedir": "^5.1.0",
       },
       "devDependencies": {
         "@semantic-release/exec": "^7.1.0",
@@ -757,8 +756,6 @@
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
-
-    "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "@clack/prompts": "^0.11.0",
     "@resvg/resvg-wasm": "^2.6.2",
     "react": "^19.2.3",
-    "satori": "^0.18.3",
-    "xdg-basedir": "^5.1.0"
+    "satori": "^0.18.3"
   },
   "devDependencies": {
     "@semantic-release/exec": "^7.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,13 +25,15 @@ USAGE:
   cc-wrapped [OPTIONS]
 
 OPTIONS:
-  --year <YYYY>    Generate wrapped for a specific year (default: current year)
-  --help, -h       Show this help message
-  --version, -v    Show version number
+  -y, --year <YYYY>        Generate wrapped for a specific year (default: current year)
+  -c, --config-dir <PATH>  Path to Claude Code config directory (default: auto-detect)
+  -h, --help               Show this help message
+  -v, --version            Show version number
 
 EXAMPLES:
-  cc-wrapped              # Generate current year wrapped
-  cc-wrapped --year 2025  # Generate 2025 wrapped
+  cc-wrapped                            # Generate current year wrapped
+  cc-wrapped --year 2025                # Generate 2025 wrapped
+  cc-wrapped -c ~/.config/claude        # Use specific config directory
 `);
 }
 
@@ -41,6 +43,7 @@ async function main() {
     args: process.argv.slice(2),
     options: {
       year: { type: "string", short: "y" },
+      "config-dir": { type: "string", short: "c" },
       help: { type: "boolean", short: "h" },
       version: { type: "boolean", short: "v" },
     },
@@ -56,6 +59,11 @@ async function main() {
   if (values.version) {
     console.log(`cc-wrapped v${VERSION}`);
     process.exit(0);
+  }
+
+  // Set config dir from CLI arg (takes priority over auto-detection)
+  if (values["config-dir"]) {
+    process.env.CLAUDE_CONFIG_DIR = values["config-dir"];
   }
 
   p.intro("claude code wrapped");
@@ -75,7 +83,7 @@ async function main() {
 
   const dataExists = await checkClaudeDataExists();
   if (!dataExists) {
-    p.cancel("Claude Code data not found in ~/.claude\n\nMake sure you have used Claude Code at least once.");
+    p.cancel("Claude Code data not found in ~/.config/claude or ~/.claude\n\nMake sure you have used Claude Code at least once.");
     process.exit(0);
   }
 


### PR DESCRIPTION
- Add support for XDG-compliant `~/.config/claude` path
- Check `~/.config/claude` first, fall back to `~/.claude`
- Add `--config-dir`/`-c` CLI option to override config path
- Remove unused `xdg-basedir` dependency